### PR TITLE
Added https redirection by default (for security considerations).

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,15 @@ var api = new ParseServer(server);
 
 var app = express();
 
+// Force https for security. Remove the following block if you want to allow http access
+app.use(function(req, res, next) {
+	if (req.headers['x-forwarded-proto'] == 'http') {
+		res.redirect('https://' + req.headers.host + req.path);
+	} else {
+		return next();
+	}
+});
+
 // Serve static assets from the /public folder
 app.use('/public', express.static(path.join(__dirname, '/public')));
 


### PR DESCRIPTION
Credit: http://www.anttdev.com/2016/02/how-to-install-your-own-parse-server-on-openshift/#comment-166
