### PR TITLE
Set default master key to non-empty string 'myMasterKey'

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var server = {
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
   appId: process.env.APP_ID || 'myAppId',
-  masterKey: process.env.MASTER_KEY || '', //Add your master key here. Keep it secret!
+  masterKey: process.env.MASTER_KEY || 'myMasterKey', //Add your master key here. Keep it secret!
   fileKey: process.env.FILE_KEY || 'invalid-file-key',
   serverURL: process.env.SERVER_URL || serverURL,  // Don't forget to change to https if needed
   liveQuery: {


### PR DESCRIPTION
Set default master key to non-empty string 'myMasterKey' otherwise Parse dashboard login will fail silently (never ending loading page) which might be hard for new users to debug.
